### PR TITLE
enhance homepage UI and add price attribute to product info

### DIFF
--- a/product/src/main/java/com/yas/product/controller/ProductController.java
+++ b/product/src/main/java/com/yas/product/controller/ProductController.java
@@ -56,8 +56,8 @@ public class ProductController {
     }
 
     @GetMapping("/storefront/products/featured")
-    public ResponseEntity<List<ProductThumbnailVm>> getFeaturedProducts() {
-        return ResponseEntity.ok(productService.getFeaturedProducts());
+    public ResponseEntity<List<ProductThumbnailGetVm>> getFeaturedProducts() {
+        return ResponseEntity.ok(productService.getListFeaturedProducts());
     }
 
     @GetMapping("/storefront/brand/{brandSlug}/products")

--- a/product/src/main/java/com/yas/product/service/ProductService.java
+++ b/product/src/main/java/com/yas/product/service/ProductService.java
@@ -370,4 +370,18 @@ public class ProductService {
                 mediaService.getMedia(product.getThumbnailMediaId()).url());
         return productThumbnailVm;
     }
+
+    public List<ProductThumbnailGetVm> getListFeaturedProducts() {
+        List<ProductThumbnailGetVm> productThumbnailVms = new ArrayList<>();
+        List<Product> products = productRepository.findAll();
+        for (Product product : products) {
+            productThumbnailVms.add(new ProductThumbnailGetVm(
+                    product.getId(),
+                    product.getName(),
+                    product.getSlug(),
+                    mediaService.getMedia(product.getThumbnailMediaId()).url(),
+                    product.getPrice()));
+        }
+        return productThumbnailVms;
+    }
 }

--- a/product/src/main/java/com/yas/product/viewmodel/ProductThumbnailGetVm.java
+++ b/product/src/main/java/com/yas/product/viewmodel/ProductThumbnailGetVm.java
@@ -1,0 +1,4 @@
+package com.yas.product.viewmodel;
+
+public record ProductThumbnailGetVm(long id, String name, String slug, String thumbnailUrl, Double price) {
+}

--- a/storefront/common/components/Layout.tsx
+++ b/storefront/common/components/Layout.tsx
@@ -15,8 +15,8 @@ export default function Layout({ children }: Props) {
         <meta name="description" content="Yet another shop storefront" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Navbar collapseOnSelect bg="dark" variant="dark">
-        <div className="container">
+      <Navbar collapseOnSelect bg="dark" variant="dark" style={{ marginBottom: 0 }}>
+        <div className="container" style={{ marginBottom: 0 }}>
           <Navbar.Brand href="/">Yas - Storefront</Navbar.Brand>
           <Navbar.Toggle />
           <Navbar.Collapse className="justify-content-end">

--- a/storefront/modules/catalog/models/ProductThumbnail.ts
+++ b/storefront/modules/catalog/models/ProductThumbnail.ts
@@ -3,4 +3,5 @@ export type ProductThumbnail = {
   name: string;
   slug: string;
   thumbnailUrl: string;
+  price: number;
 };

--- a/storefront/modules/catalog/services/ProductService.ts
+++ b/storefront/modules/catalog/services/ProductService.ts
@@ -14,3 +14,12 @@ export async function getProduct(slug: string): Promise<Product> {
   );
   return response.json();
 }
+
+export function formatPrice(price: number): any {
+  var formatter = new Intl.NumberFormat('vi-VN', {
+    style: 'currency',
+    currency: 'VND',
+  });
+
+  return formatter.format(price);
+}

--- a/storefront/pages/_app.tsx
+++ b/storefront/pages/_app.tsx
@@ -16,6 +16,10 @@ function MyApp({ Component, pageProps }: AppProps) {
           rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css"
         ></link>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+        ></link>
       </Head>
       <Layout>
         <Component {...pageProps} />

--- a/storefront/pages/index.tsx
+++ b/storefront/pages/index.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
-import { getFeaturedProducts } from '../modules/catalog/services/ProductService';
+import { getFeaturedProducts, formatPrice } from '../modules/catalog/services/ProductService';
 import type { ProductThumbnail } from '../modules/catalog/models/ProductThumbnail';
 import styles from '../styles/Home.module.css';
 import { Button } from 'react-bootstrap';
@@ -16,21 +16,33 @@ const Home = ({ products }: Props) => {
   return (
     <>
       <h2>Featured products</h2>
-      <Row xs={2} md={4} className="g-4">
+      <Row xs={2} md={5} className="g-4">
         {products.map((product) => (
           <Col key={product.id}>
-            <Card>
-              <Card.Img
-                variant="top"
-                src={product.thumbnailUrl}
-                style={{ width: '100%', height: '18rem' }}
-              />
+            <Card className="item-product" style={{ padding: '0', borderRadius: 0, margin: 0 }}>
+              <Link href={`/products/${product.slug}`}>
+                <Card.Img
+                  variant="top"
+                  src={product.thumbnailUrl}
+                  style={{ width: '100%', height: '14rem', cursor: 'pointer' }}
+                />
+              </Link>
               <Card.Body>
-                <Card.Title>{product.name}</Card.Title>
-                <Card.Text>Price: $0.0</Card.Text>
-                <Button variant="primary" className="">
-                  <Link href={`/products/${product.slug}`}>More detail</Link>
-                </Button>
+                <Link href={`/products/${product.slug}`}>
+                  <div style={{ height: '45px', cursor: 'pointer' }}>
+                    <a style={{ fontWeight: 'bolder' }}>{product.name}</a>
+                  </div>
+                </Link>
+
+                <span style={{ color: 'red', fontWeight: 'bolder' }}>
+                  {formatPrice(product.price)}
+                </span>
+                <br />
+                <span className="fa fa-star checked"></span>
+                <span className="fa fa-star checked"></span>
+                <span className="fa fa-star checked"></span>
+                <span className="fa fa-star checked"></span>
+                <span className="fa fa-star checked"></span>
               </Card.Body>
             </Card>
           </Col>

--- a/storefront/styles/globals.css
+++ b/storefront/styles/globals.css
@@ -167,3 +167,16 @@ img-thumbnail {
   display: block;
   font-style: italic;
 }
+
+.checked {
+  color: orange;
+}
+
+.item-product {
+  transition: transform 0.2s; /* Animation */
+}
+
+.item-product:hover {
+  color: #0070f3;
+  transform: scale(1.1);
+}


### PR DESCRIPTION
- Old UI
![image](https://user-images.githubusercontent.com/103627485/196842586-1cfb41b5-5654-4c77-aa9d-232a51186f6a.png)

-New UI:
![image](https://user-images.githubusercontent.com/103627485/196842687-513c243f-88d0-4a40-8bdb-07cfd8969fe6.png)


- Add animation when hover and instead of click on "More detail" button. Now we just click on the product

https://user-images.githubusercontent.com/103627485/196842807-61a37d18-870d-4c78-af7b-003c57b413e9.mp4

- Add product price

