### PR TITLE
Using otlp exporter instead of zipkin exporter

### DIFF
--- a/backoffice-bff/pom.xml
+++ b/backoffice-bff/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -15,7 +15,7 @@
 	<description>Backend for backoffice</description>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
         <sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-backoffice-bff</sonar.projectKey>
@@ -47,7 +47,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/backoffice-bff/src/main/java/com/yas/backofficebff/Application.java
+++ b/backoffice-bff/src/main/java/com/yas/backofficebff/Application.java
@@ -1,9 +1,7 @@
 package com.yas.backofficebff;
 
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 
 @SpringBootApplication
@@ -13,12 +11,4 @@ public class Application {
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
-	}
-
 }

--- a/backoffice-bff/src/main/java/com/yas/backofficebff/config/SecurityConfig.java
+++ b/backoffice-bff/src/main/java/com/yas/backofficebff/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.yas.backofficebff.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,18 +26,16 @@ public class SecurityConfig {
 
     @Bean
     public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-        http
-                .authorizeExchange()
-                .pathMatchers("/health").permitAll()
-                .pathMatchers("/actuator/prometheus").permitAll()
-                .anyExchange().hasAnyRole("ADMIN")
-                .and()
-                .oauth2Login()
-                .and()
-                .httpBasic().disable()
-                .formLogin().disable()
-                .csrf().disable();
-        return http.build();
+        return http
+                .authorizeExchange(auth -> auth
+                    .pathMatchers("/health").permitAll()
+                    .pathMatchers("/actuator/prometheus").permitAll()
+                    .anyExchange().hasAnyRole("ADMIN"))
+                .oauth2Login(Customizer.withDefaults())
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .build();
     }
     
     @Bean

--- a/backoffice-bff/src/main/resources/application.yaml
+++ b/backoffice-bff/src/main/resources/application.yaml
@@ -18,6 +18,9 @@ spring:
             client-secret: TVacLC0cQ8tiiEKiTVerTb2YvwQ1TRJF
             scope: openid, profile, email, roles
 management:
+  otlp:
+    tracing:
+      endpoint: http://tempo:4318/v1/traces
   tracing:
     sampling:
       probability: "1.0"
@@ -31,6 +34,8 @@ management:
         http:
           server:
             requests: true
+    tags:
+      application: ${spring.application.name}
 logging:
   pattern:
     level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"

--- a/cart/pom.xml
+++ b/cart/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -21,7 +21,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-cart</sonar.projectKey>
@@ -93,7 +93,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/cart/src/main/java/com/yas/cart/CartApplication.java
+++ b/cart/src/main/java/com/yas/cart/CartApplication.java
@@ -1,12 +1,9 @@
 package com.yas.cart;
 
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import com.yas.cart.config.ServiceUrlConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-
-import com.yas.cart.config.ServiceUrlConfig;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -15,11 +12,4 @@ public class CartApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(CartApplication.class, args);
 	}
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter () {
-		return ZipkinSpanExporter.builder().setEndpoint("http://tempo:9411/api/v2/spans").build();
-	}
-
-
 }

--- a/cart/src/main/java/com/yas/cart/config/SecurityConfig.java
+++ b/cart/src/main/java/com/yas/cart/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.cart.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,16 +21,14 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/carts", "/storefront/carts/**").hasRole("CUSTOMER")
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/carts", "/storefront/carts/**").hasRole("CUSTOMER")
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/cart/src/main/resources/application.properties
+++ b/cart/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8084
 server.servlet.context-path=/cart
 
 spring.application.name=cart
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/customer/pom.xml
+++ b/customer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
         <org.lombok.version>1.18.22</org.lombok.version>
-        <spring-cloud.version>2022.0.1</spring-cloud.version>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
         <sonar.organization>nashtech-garage</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectKey>nashtech-garage_yas-customer</sonar.projectKey>
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.loki4j</groupId>

--- a/customer/src/main/java/com/yas/customer/CustomerApplication.java
+++ b/customer/src/main/java/com/yas/customer/CustomerApplication.java
@@ -1,11 +1,9 @@
 package com.yas.customer;
 
 import com.yas.customer.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -14,11 +12,4 @@ public class CustomerApplication {
     public static void main(String[] args) {
         SpringApplication.run(CustomerApplication.class, args);
     }
-
-    @Bean
-    public ZipkinSpanExporter zipkinSpanExporter() {
-        return ZipkinSpanExporter.builder().setEndpoint("http://tempo:9411/api/v2/spans").build();
-    }
-
-
 }

--- a/customer/src/main/java/com/yas/customer/config/SecurityConfig.java
+++ b/customer/src/main/java/com/yas/customer/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.customer.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,16 +21,14 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/customer/**").hasRole("CUSTOMER")
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/customer/**").hasRole("CUSTOMER")
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/customer/src/main/resources/application.properties
+++ b/customer/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8088
 server.servlet.context-path=/customer
 
 spring.application.name=customer
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/docker-compose.o11y.yml
+++ b/docker-compose.o11y.yml
@@ -27,6 +27,33 @@ services:
       - "3009:3000"
     networks:
       - yas-network
+  loki:
+    image: grafana/loki:2.7.4
+    extra_hosts: [ 'host.docker.internal:host-gateway' ]
+    command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    ports:
+      - "3100:3100"                                   # loki needs to be exposed so it receives logs
+    environment:
+      - JAEGER_AGENT_HOST=tempo
+      - JAEGER_ENDPOINT=http://tempo:14268/api/traces # send traces to Tempo
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
+    networks:
+      - yas-network
+  tempo:
+    image: grafana/tempo:main-0c1eb27
+    extra_hosts: [ 'host.docker.internal:host-gateway' ]
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./docker/tempo/tempo-local.yaml:/etc/tempo.yaml:ro
+      - ./tempo-data:/tmp/tempo
+    ports:
+      - "14268"  # jaeger ingest
+      - "9411:9411" # zipkin
+      - "4317:4317" # otlp grpc ingest
+      - "4318:4318" # otlp http ingest
+    networks:
+      - yas-network
 
 networks:
   yas-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,33 +301,6 @@ services:
       - kafka-connect
     networks:
       - yas-network
-  loki:
-    image: grafana/loki:2.7.4
-    extra_hosts: [ 'host.docker.internal:host-gateway' ]
-    command: [ "-config.file=/etc/loki/local-config.yaml" ]
-    ports:
-      - "3100:3100"                                   # loki needs to be exposed so it receives logs
-    environment:
-      - JAEGER_AGENT_HOST=tempo
-      - JAEGER_ENDPOINT=http://tempo:14268/api/traces # send traces to Tempo
-      - JAEGER_SAMPLER_TYPE=const
-      - JAEGER_SAMPLER_PARAM=1
-    networks:
-      - yas-network
-  tempo:
-    image: grafana/tempo:main-0c1eb27
-    extra_hosts: [ 'host.docker.internal:host-gateway' ]
-    command: [ "-config.file=/etc/tempo.yaml" ]
-    volumes:
-      - ./docker/tempo/tempo-local.yaml:/etc/tempo.yaml:ro
-      - ./tempo-data:/tmp/tempo
-    ports:
-      - "14268"  # jaeger ingest
-      - "9411:9411" # zipkin
-      #- "4317:4317" # otlp grpc ingest
-      #- "4318:4318" # otlp http ingest
-    networks:
-      - yas-network
 
 networks:
   yas-network:

--- a/docker/tempo/tempo-local.yaml
+++ b/docker/tempo/tempo-local.yaml
@@ -4,6 +4,10 @@ server:
 distributor:
     receivers:
         zipkin:
+        otlp:
+            protocols:
+                grpc:
+                http:
 
 storage:
     trace:

--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
         <springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
         <org.lombok.version>1.18.22</org.lombok.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <spring-cloud.version>2022.0.1</spring-cloud.version>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
         <sonar.organization>nashtech-garage</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectKey>nashtech-garage_yas-inventory</sonar.projectKey>
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.loki4j</groupId>

--- a/inventory/src/main/java/com/yas/inventory/InventoryApplication.java
+++ b/inventory/src/main/java/com/yas/inventory/InventoryApplication.java
@@ -1,24 +1,14 @@
 package com.yas.inventory;
 
 import com.yas.inventory.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
 public class InventoryApplication {
     public static void main(String[] args) {
         SpringApplication.run(InventoryApplication.class, args);
-    }
-
-
-    @Bean
-    public ZipkinSpanExporter zipkinSpanExporter() {
-        return ZipkinSpanExporter.builder()
-                .setEndpoint("http://tempo:9411/api/v2/spans")
-                .build();
     }
 }

--- a/inventory/src/main/java/com/yas/inventory/config/SecurityConfig.java
+++ b/inventory/src/main/java/com/yas/inventory/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.inventory.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,15 +21,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/inventory/src/main/resources/application.properties
+++ b/inventory/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8090
 server.servlet.context-path=/inventory
 
 spring.application.name=inventory
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/location/pom.xml
+++ b/location/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
         <springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
         <org.lombok.version>1.18.22</org.lombok.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <spring-cloud.version>2022.0.1</spring-cloud.version>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
         <sonar.organization>nashtech-garage</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectKey>nashtech-garage_yas-location</sonar.projectKey>
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.loki4j</groupId>

--- a/location/src/main/java/com/yas/location/LocationApplication.java
+++ b/location/src/main/java/com/yas/location/LocationApplication.java
@@ -1,22 +1,12 @@
 package com.yas.location;
 
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class LocationApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(LocationApplication.class, args);
-  }
-
-
-  @Bean
-  public ZipkinSpanExporter zipkinSpanExporter() {
-    return ZipkinSpanExporter.builder()
-        .setEndpoint("http://tempo:9411/api/v2/spans")
-        .build();
   }
 }

--- a/location/src/main/java/com/yas/location/config/SecurityConfig.java
+++ b/location/src/main/java/com/yas/location/config/SecurityConfig.java
@@ -1,11 +1,9 @@
 package com.yas.location.config;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -14,21 +12,22 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Configuration
 public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
-    http
-        .authorizeHttpRequests()
-        .requestMatchers("/storefront/**").permitAll()
-        .requestMatchers("/backoffice/**").hasRole("ADMIN")
-        .anyRequest().authenticated()
-        .and()
-        .oauth2ResourceServer().jwt();
-
-    return http.build();
+    return http
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .build();
   }
 
   @Bean

--- a/location/src/main/resources/application.properties
+++ b/location/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8086
 server.servlet.context-path=/location
 
 spring.application.name=location
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/media/pom.xml
+++ b/media/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -68,7 +68,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/media/src/main/java/com/yas/media/MediaApplication.java
+++ b/media/src/main/java/com/yas/media/MediaApplication.java
@@ -1,11 +1,9 @@
 package com.yas.media;
 
 import com.yas.media.config.YasConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(YasConfig.class)
@@ -13,14 +11,6 @@ public class MediaApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(MediaApplication.class, args);
-	}
-
-	//TODO move the zipkin endpoint to config file. Consider using Autoconfigure when it ready (alpha at the moment)
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
 	}
 
 }

--- a/media/src/main/java/com/yas/media/config/SecurityConfig.java
+++ b/media/src/main/java/com/yas/media/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -21,15 +22,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers(HttpMethod.GET, "/medias/**").permitAll()
-                .requestMatchers("/medias").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers(HttpMethod.GET, "/medias/**").permitAll()
+                    .requestMatchers("/medias").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/media/src/main/resources/application.properties
+++ b/media/src/main/resources/application.properties
@@ -6,8 +6,11 @@ spring.datasource.username=admin
 spring.datasource.password=admin
 
 spring.application.name=media
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/order/pom.xml
+++ b/order/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-order</sonar.projectKey>
@@ -96,7 +96,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/order/src/main/java/com/yas/order/OrderApplication.java
+++ b/order/src/main/java/com/yas/order/OrderApplication.java
@@ -1,11 +1,9 @@
 package com.yas.order;
 
 import com.yas.order.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,13 +11,5 @@ public class OrderApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(OrderApplication.class, args);
-	}
-
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
 	}
 }

--- a/order/src/main/java/com/yas/order/config/SecurityConfig.java
+++ b/order/src/main/java/com/yas/order/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.order.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,15 +21,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/storefront/**").permitAll()
+                        .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/order/src/main/java/com/yas/order/repository/OrderRepository.java
+++ b/order/src/main/java/com/yas/order/repository/OrderRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT EXISTS (" +
-            "SELECT 1 FROM Order o INNER JOIN OrderItem oi ON o.id=oi.orderId " +
+            "SELECT 1 FROM Order o INNER JOIN o.orderItems oi " +
             "WHERE o.createdBy=:createdBy " +
             "       AND o.orderStatus=COMPLETED " +
             "       AND oi.productId in :productId" +

--- a/order/src/main/resources/application.properties
+++ b/order/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8085
 server.servlet.context-path=/order
 
 spring.application.name=order
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/payment-paypal/pom.xml
+++ b/payment-paypal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-payment-paypal</sonar.projectKey>
@@ -96,7 +96,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/payment-paypal/src/main/java/com/yas/paymentpaypal/PaymentPaypalApplication.java
+++ b/payment-paypal/src/main/java/com/yas/paymentpaypal/PaymentPaypalApplication.java
@@ -1,11 +1,9 @@
 package com.yas.paymentpaypal;
 
 import com.yas.paymentpaypal.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,12 +11,5 @@ public class PaymentPaypalApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(PaymentPaypalApplication.class, args);
-	}
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
 	}
 }

--- a/payment-paypal/src/main/java/com/yas/paymentpaypal/config/SecurityConfig.java
+++ b/payment-paypal/src/main/java/com/yas/paymentpaypal/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.paymentpaypal.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -21,16 +22,14 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/capture" , "/cancel").permitAll()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/capture" , "/cancel").permitAll()
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/payment-paypal/src/main/resources/application.properties
+++ b/payment-paypal/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8093
 server.servlet.context-path=/payment-paypal
 
 spring.application.name=payment-paypal
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-payment</sonar.projectKey>
@@ -91,7 +91,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/payment/src/main/java/com/yas/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/yas/payment/PaymentApplication.java
@@ -1,11 +1,9 @@
 package com.yas.payment;
 
 import com.yas.payment.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,12 +11,5 @@ public class PaymentApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(PaymentApplication.class, args);
-	}
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
 	}
 }

--- a/payment/src/main/java/com/yas/payment/config/SecurityConfig.java
+++ b/payment/src/main/java/com/yas/payment/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.payment.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,18 +21,15 @@ import java.util.stream.Collectors;
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .requestMatchers("/payment-providers/**").permitAll()
-                .requestMatchers("/capture-payment").permitAll()
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .requestMatchers("/payment-providers/**").permitAll()
+                    .requestMatchers("/capture-payment").permitAll()
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/payment/src/main/resources/application.properties
+++ b/payment/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8081
 server.servlet.context-path=/payment
 
 spring.application.name=payment
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/payment/src/test/resources/application.properties
+++ b/payment/src/test/resources/application.properties
@@ -1,6 +1,15 @@
 # Setting Spring context path & port
 server.servlet.context-path=/v1
+spring.application.name=payment
 server.port=8081
+
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
+management.tracing.sampling.probability=1.0
+management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
+
+logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 
 spring.datasource.url=jdbc:h2:mem:testdb;NON_KEYWORDS=VALUE
 spring.datasource.driverClassName=org.h2.Driver

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -96,7 +96,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/product/src/main/java/com/yas/product/ProductApplication.java
+++ b/product/src/main/java/com/yas/product/ProductApplication.java
@@ -1,11 +1,9 @@
 package com.yas.product;
 
 import com.yas.product.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,13 +11,6 @@ public class ProductApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ProductApplication.class, args);
-	}
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-						.setEndpoint("http://tempo:9411/api/v2/spans")
-						.build();
 	}
 
 }

--- a/product/src/main/java/com/yas/product/config/SecurityConfig.java
+++ b/product/src/main/java/com/yas/product/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.product.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,15 +21,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/product/src/main/resources/application.properties
+++ b/product/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8080
 server.servlet.context-path=/product
 
 spring.application.name=product
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-promotion</sonar.projectKey>
@@ -90,7 +90,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/promotion/src/main/java/com/yas/promotion/PromotionApplication.java
+++ b/promotion/src/main/java/com/yas/promotion/PromotionApplication.java
@@ -1,11 +1,9 @@
 package com.yas.promotion;
 
 import com.yas.promotion.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,12 +11,5 @@ public class PromotionApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(PromotionApplication.class, args);
-    }
-
-    @Bean
-    public ZipkinSpanExporter zipkinSpanExporter() {
-        return ZipkinSpanExporter.builder()
-                .setEndpoint("http://tempo:9411/api/v2/spans")
-                .build();
     }
 }

--- a/promotion/src/main/java/com/yas/promotion/config/SecurityConfig.java
+++ b/promotion/src/main/java/com/yas/promotion/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.promotion.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,15 +21,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/promotion/src/main/resources/application.properties
+++ b/promotion/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8092
 server.servlet.context-path=/promotion
 
 spring.application.name=promotion
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/rating/pom.xml
+++ b/rating/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-rating</sonar.projectKey>
@@ -95,7 +95,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/rating/src/main/java/com/yas/rating/RatingApplication.java
+++ b/rating/src/main/java/com/yas/rating/RatingApplication.java
@@ -1,11 +1,9 @@
 package com.yas.rating;
 
 import com.yas.rating.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,12 +11,5 @@ public class RatingApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(RatingApplication.class, args);
-	}
-
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
 	}
 }

--- a/rating/src/main/java/com/yas/rating/config/SecurityConfig.java
+++ b/rating/src/main/java/com/yas/rating/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.rating.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,15 +21,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/rating/src/main/resources/application.properties
+++ b/rating/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8089
 server.servlet.context-path=/rating
 
 spring.application.name=rating
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.4</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -20,7 +20,7 @@
 		<springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
 		<org.lombok.version>1.18.22</org.lombok.version>
 		<org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-search</sonar.projectKey>
@@ -90,7 +90,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/search/src/main/java/com/yas/search/ElasticsearchApplication.java
+++ b/search/src/main/java/com/yas/search/ElasticsearchApplication.java
@@ -1,12 +1,10 @@
 package com.yas.search;
 
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
+import com.yas.search.config.ServiceUrlConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import com.yas.search.config.ServiceUrlConfig;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -16,12 +14,5 @@ public class ElasticsearchApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ElasticsearchApplication.class, args);
-    }
-
-    @Bean
-    public ZipkinSpanExporter zipkinSpanExporter() {
-        return ZipkinSpanExporter.builder()
-                .setEndpoint("http://tempo:9411/api/v2/spans")
-                .build();
     }
 }

--- a/search/src/main/java/com/yas/search/config/SecurityConfig.java
+++ b/search/src/main/java/com/yas/search/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.yas.search.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -19,15 +20,13 @@ import java.util.stream.Collectors;
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests()
-                .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-                .and()
-                .oauth2ResourceServer().jwt();
-
-        return http.build();
+        return http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .build();
     }
 
     @Bean

--- a/search/src/main/resources/application.properties
+++ b/search/src/main/resources/application.properties
@@ -4,8 +4,11 @@ server.port=8092
 server.servlet.context-path=/search
 
 spring.application.name=search
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 

--- a/storefront-bff/pom.xml
+++ b/storefront-bff/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.yas</groupId>
@@ -15,7 +15,7 @@
 	<description>Back end for Storefront</description>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<spring-cloud.version>2022.0.3</spring-cloud.version>
 		<sonar.organization>nashtech-garage</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.projectKey>nashtech-garage_yas-storefront-bff</sonar.projectKey>
@@ -57,7 +57,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-zipkin</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.loki4j</groupId>

--- a/storefront-bff/src/main/java/com/yas/storefrontbff/StorefrontBffApplication.java
+++ b/storefront-bff/src/main/java/com/yas/storefrontbff/StorefrontBffApplication.java
@@ -1,11 +1,9 @@
 package com.yas.storefrontbff;
 
 import com.yas.storefrontbff.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 
 @SpringBootApplication
@@ -15,14 +13,6 @@ public class StorefrontBffApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(StorefrontBffApplication.class, args);
-	}
-
-	//TODO move the zipkin endpoint to config file. Consider using Autoconfigure when it ready (alpha at the moment)
-	@Bean
-	public ZipkinSpanExporter zipkinSpanExporter() {
-		return ZipkinSpanExporter.builder()
-				.setEndpoint("http://tempo:9411/api/v2/spans")
-				.build();
 	}
 
 }

--- a/storefront-bff/src/main/java/com/yas/storefrontbff/config/SecurityConfig.java
+++ b/storefront-bff/src/main/java/com/yas/storefrontbff/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.yas.storefrontbff.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,18 +26,16 @@ public class SecurityConfig {
 
     @Bean
     public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-        http
-                .authorizeExchange()
-                .pathMatchers("/profile/**").authenticated()
-                .pathMatchers("/address/**").authenticated()
-                .anyExchange().permitAll()
-                .and()
-                .oauth2Login()
-                .and()
-                .httpBasic().disable()
-                .formLogin().disable()
-                .csrf().disable();
-        return http.build();
+        return http
+                .authorizeExchange(auth -> auth
+                    .pathMatchers("/profile/**").authenticated()
+                    .pathMatchers("/address/**").authenticated()
+                    .anyExchange().permitAll())
+                .oauth2Login(Customizer.withDefaults())
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .build();
     }
 
     @Bean

--- a/storefront-bff/src/main/resources/application.yaml
+++ b/storefront-bff/src/main/resources/application.yaml
@@ -18,6 +18,9 @@ spring:
             client-secret: ZrU9I0q2uXBglBnmvyJdkl1lf0ncr8tn
             scope: openid, profile, email, roles
 management:
+  otlp:
+    tracing:
+      endpoint: http://tempo:4318/v1/traces
   tracing:
     sampling:
       probability: "1.0"
@@ -31,6 +34,8 @@ management:
         http:
           server:
             requests: true
+    tags:
+      application: ${spring.application.name}
 logging:
   pattern:
     level: "%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]"

--- a/tax/pom.xml
+++ b/tax/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.yas</groupId>
@@ -20,7 +20,7 @@
         <springdoc-openapi-starter-webmvc-ui.version>2.0.2</springdoc-openapi-starter-webmvc-ui.version>
         <org.lombok.version>1.18.22</org.lombok.version>
         <org.mapstruct.version>1.4.1.Final</org.mapstruct.version>
-        <spring-cloud.version>2022.0.1</spring-cloud.version>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
         <sonar.organization>nashtech-garage</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectKey>nashtech-garage_yas-tax</sonar.projectKey>
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-zipkin</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.loki4j</groupId>

--- a/tax/src/main/java/com/yas/tax/TaxApplication.java
+++ b/tax/src/main/java/com/yas/tax/TaxApplication.java
@@ -1,11 +1,9 @@
 package com.yas.tax;
 
 import com.yas.tax.config.ServiceUrlConfig;
-import io.opentelemetry.exporter.zipkin.ZipkinSpanExporter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ServiceUrlConfig.class)
@@ -13,12 +11,5 @@ public class TaxApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(TaxApplication.class, args);
-  }
-  
-  @Bean
-  public ZipkinSpanExporter zipkinSpanExporter() {
-    return ZipkinSpanExporter.builder()
-        .setEndpoint("http://tempo:9411/api/v2/spans")
-        .build();
   }
 }

--- a/tax/src/main/resources/application.properties
+++ b/tax/src/main/resources/application.properties
@@ -2,8 +2,11 @@ server.port=8091
 server.servlet.context-path=/tax
 
 spring.application.name=tax
+management.otlp.tracing.endpoint=http://tempo:4318/v1/traces
 management.tracing.sampling.probability=1.0
 management.endpoints.web.exposure.include=prometheus
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.tags.application=${spring.application.name}
 
 logging.pattern.level=%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]
 


### PR DESCRIPTION
For the purpose apply observability on the k8s environment below is the change for all backend applications
- Upgrade spring boot version to 3.1.0
- Upgrade spring cloud version to 2022.0.3
- Replace zipkin exporter by otlp exporter library
- Remove hard code zipkin export configuration in Application class
- Config tracing endpoint otpl in the application.yaml or application.property
- Refactor security configuration deprecated on new version Spring boot
- Enable otlp receiver in the tempo server