### PR TITLE
Config security allow access actuator without permission

### DIFF
--- a/backoffice-bff/src/main/java/com/yas/backofficebff/config/SecurityConfig.java
+++ b/backoffice-bff/src/main/java/com/yas/backofficebff/config/SecurityConfig.java
@@ -28,8 +28,7 @@ public class SecurityConfig {
     public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
         return http
                 .authorizeExchange(auth -> auth
-                    .pathMatchers("/health").permitAll()
-                    .pathMatchers("/actuator/prometheus").permitAll()
+                    .pathMatchers("/health", "/actuator/prometheus", "/actuator/health/**").permitAll()
                     .anyExchange().hasAnyRole("ADMIN"))
                 .oauth2Login(Customizer.withDefaults())
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)

--- a/cart/src/main/java/com/yas/cart/config/SecurityConfig.java
+++ b/cart/src/main/java/com/yas/cart/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                     .requestMatchers("/storefront/carts", "/storefront/carts/**").hasRole("CUSTOMER")
                     .requestMatchers("/storefront/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                    .requestMatchers("/actuator/**").permitAll()
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();

--- a/cart/src/main/java/com/yas/cart/config/SecurityConfig.java
+++ b/cart/src/main/java/com/yas/cart/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,18 +22,14 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/carts", "/storefront/carts/**").hasRole("CUSTOMER")
                     .requestMatchers("/storefront/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
-                    .requestMatchers("/actuator/**").permitAll()
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/customer/src/main/java/com/yas/customer/config/SecurityConfig.java
+++ b/customer/src/main/java/com/yas/customer/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,18 +22,14 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/customer/**").hasRole("CUSTOMER")
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/customer/src/main/java/com/yas/customer/config/SecurityConfig.java
+++ b/customer/src/main/java/com/yas/customer/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/customer/**").hasRole("CUSTOMER")
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/inventory/src/main/java/com/yas/inventory/config/SecurityConfig.java
+++ b/inventory/src/main/java/com/yas/inventory/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/inventory/src/main/java/com/yas/inventory/config/SecurityConfig.java
+++ b/inventory/src/main/java/com/yas/inventory/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,17 +22,13 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/location/src/main/java/com/yas/location/config/SecurityConfig.java
+++ b/location/src/main/java/com/yas/location/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     return http
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/location/src/main/java/com/yas/location/config/SecurityConfig.java
+++ b/location/src/main/java/com/yas/location/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,19 +22,13 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     return http
             .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
             .build();
-  }
-
-  @Bean
-  public WebSecurityCustomizer webSecurityCustomizer() {
-    return web -> web.ignoring()
-        .requestMatchers("/actuator/prometheus", "/swagger-ui", "/swagger-ui/**", "/error",
-            "/v3/api-docs/**");
   }
 
   @Bean

--- a/media/src/main/java/com/yas/media/config/SecurityConfig.java
+++ b/media/src/main/java/com/yas/media/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -24,17 +23,13 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/medias/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/medias").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus", "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/media/src/main/java/com/yas/media/config/SecurityConfig.java
+++ b/media/src/main/java/com/yas/media/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers(HttpMethod.GET, "/medias/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/medias").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/order/src/main/java/com/yas/order/config/SecurityConfig.java
+++ b/order/src/main/java/com/yas/order/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,17 +22,13 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                                "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/storefront/**").permitAll()
-                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/backoffice/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/order/src/main/java/com/yas/order/config/SecurityConfig.java
+++ b/order/src/main/java/com/yas/order/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/storefront/**").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/backoffice/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/payment-paypal/src/main/java/com/yas/paymentpaypal/config/SecurityConfig.java
+++ b/payment-paypal/src/main/java/com/yas/paymentpaypal/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -24,6 +23,8 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/capture" , "/cancel").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
                     .requestMatchers("/actuator/**").permitAll()
@@ -31,11 +32,6 @@ public class SecurityConfig {
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/payment-paypal/src/main/java/com/yas/paymentpaypal/config/SecurityConfig.java
+++ b/payment-paypal/src/main/java/com/yas/paymentpaypal/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/capture" , "/cancel").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/payment/src/main/java/com/yas/payment/config/SecurityConfig.java
+++ b/payment/src/main/java/com/yas/payment/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,6 +22,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .requestMatchers("/payment-providers/**").permitAll()
@@ -31,11 +32,6 @@ public class SecurityConfig {
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**", "/capture-payment");
     }
 
     @Bean

--- a/payment/src/main/java/com/yas/payment/config/SecurityConfig.java
+++ b/payment/src/main/java/com/yas/payment/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .requestMatchers("/payment-providers/**").permitAll()
                     .requestMatchers("/capture-payment").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();

--- a/product/src/main/java/com/yas/product/config/SecurityConfig.java
+++ b/product/src/main/java/com/yas/product/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/product/src/main/java/com/yas/product/config/SecurityConfig.java
+++ b/product/src/main/java/com/yas/product/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,17 +22,13 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/promotion/src/main/java/com/yas/promotion/config/SecurityConfig.java
+++ b/promotion/src/main/java/com/yas/promotion/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/promotion/src/main/java/com/yas/promotion/config/SecurityConfig.java
+++ b/promotion/src/main/java/com/yas/promotion/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,19 +22,13 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring()
-                .requestMatchers("/actuator/prometheus", "/swagger-ui", "/swagger-ui/**", "/error",
-                        "/v3/api-docs/**");
     }
 
     @Bean

--- a/rating/src/main/java/com/yas/rating/config/SecurityConfig.java
+++ b/rating/src/main/java/com/yas/rating/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/rating/src/main/java/com/yas/rating/config/SecurityConfig.java
+++ b/rating/src/main/java/com/yas/rating/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,17 +22,13 @@ public class SecurityConfig {
 
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus","/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/search/src/main/java/com/yas/search/config/SecurityConfig.java
+++ b/search/src/main/java/com/yas/search/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -22,17 +21,13 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                            "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/storefront/**").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
                 .build();
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/actuator/prometheus", "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**");
     }
 
     @Bean

--- a/search/src/main/java/com/yas/search/config/SecurityConfig.java
+++ b/search/src/main/java/com/yas/search/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/storefront/**").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .requestMatchers("/backoffice/**").hasRole("ADMIN")
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/tax/src/main/java/com/yas/tax/config/SecurityConfig.java
+++ b/tax/src/main/java/com/yas/tax/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
@@ -19,16 +20,14 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
-    http
-        .authorizeHttpRequests()
-        .requestMatchers("/storefront/**").permitAll()
-        .requestMatchers("/backoffice/**").hasRole("ADMIN")
-        .anyRequest().authenticated()
-        .and()
-        .oauth2ResourceServer().jwt();
-
-    return http.build();
+    return http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/storefront/**").permitAll()
+                .requestMatchers("/actuator/**").permitAll()
+                .requestMatchers("/backoffice/**").hasRole("ADMIN")
+                .anyRequest().authenticated())
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .build();
   }
 
   @Bean

--- a/tax/src/main/java/com/yas/tax/config/SecurityConfig.java
+++ b/tax/src/main/java/com/yas/tax/config/SecurityConfig.java
@@ -1,19 +1,19 @@
 package com.yas.tax.config;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SecurityConfig {
@@ -22,19 +22,13 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     return http
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/prometheus", "/actuator/health/**",
+                        "/swagger-ui", "/swagger-ui/**", "/error", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/storefront/**").permitAll()
-                .requestMatchers("/actuator/**").permitAll()
                 .requestMatchers("/backoffice/**").hasRole("ADMIN")
                 .anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
             .build();
-  }
-
-  @Bean
-  public WebSecurityCustomizer webSecurityCustomizer() {
-    return web -> web.ignoring()
-        .requestMatchers("/actuator/prometheus", "/swagger-ui", "/swagger-ui/**", "/error",
-            "/v3/api-docs/**");
   }
 
   @Bean


### PR DESCRIPTION
When YAS applications deploy to k8s cluster environment, the k8s need to check liveness and readiness on the pods, however the 401 error occur when check liveness and readiness, so YAS applications need open urls actuator