### PR TITLE
Change browser environment to server environment nexjs

### DIFF
--- a/storefront/.env.development
+++ b/storefront/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE_PATH=http://localhost:8087/api
+API_BASE_PATH=http://localhost:8087/api

--- a/storefront/.env.production
+++ b/storefront/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE_PATH=http://storefront/api
+API_BASE_PATH=http://storefront/api

--- a/storefront/modules/catalog/services/ProductService.ts
+++ b/storefront/modules/catalog/services/ProductService.ts
@@ -11,24 +11,20 @@ export async function getFeaturedProducts(pageNo: number): Promise<ProductFeatur
 }
 
 export async function getProductDetail(slug: string): Promise<ProductDetail> {
-  const response = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH + '/product/storefront/product/' + slug
-  );
+  const response = await fetch(process.env.API_BASE_PATH + '/product/storefront/product/' + slug);
   return response.json();
 }
 
 export async function getProductOptionValues(productId: number): Promise<ProductOptionValueGet[]> {
   const res = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH + `/product/storefront/product-option-values/${productId}`
+    `${process.env.API_BASE_PATH}/product/storefront/product-option-values/${productId}`
   );
   if (res.status >= 200 && res.status < 300) return res.json();
   return Promise.reject(res);
 }
 
 export async function getProductByMultiParams(queryString: string): Promise<ProductAll> {
-  const res = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH + `/product/storefront/products?${queryString}`
-  );
+  const res = await fetch(`/api/product/storefront/products?${queryString}`);
   return res.json();
 }
 
@@ -36,31 +32,25 @@ export async function getProductVariationsByParentId(
   parentId: number
 ): Promise<ProductVariation[]> {
   const res = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH + `/product/storefront/product-variations/${parentId}`
+    `${process.env.API_BASE_PATH}/product/storefront/product-variations/${parentId}`
   );
   if (res.status >= 200 && res.status < 300) return res.json();
   return Promise.reject(res);
 }
 
 export async function getProductSlug(productId: number): Promise<ProductSlug> {
-  const res = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH + `/product/storefront/productions/${productId}/slug`
-  );
+  const res = await fetch(`/api/product/storefront/productions/${productId}/slug`);
   if (res.status >= 200 && res.status < 300) return res.json();
   return Promise.reject(res);
 }
 
 export async function getRelatedProductsByProductId(productId: number): Promise<ProductsGet> {
-  const res = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH +
-      `/product/storefront/products/related-products/${productId}`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  const res = await fetch(`/api/product/storefront/products/related-products/${productId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
   if (res.status >= 200 && res.status < 300) return res.json();
   return Promise.reject(res);
 }

--- a/storefront/modules/order/services/OrderService.ts
+++ b/storefront/modules/order/services/OrderService.ts
@@ -41,13 +41,10 @@ export async function createCheckout(checkout: Checkout): Promise<Checkout | nul
 }
 
 export async function getCheckoutById(id: string) {
-  const response = await fetch(
-    process.env.NEXT_PUBLIC_API_BASE_PATH + '/order/storefront/checkouts/' + id,
-    {
-      method: 'GET',
-      headers: { 'Content-type': 'application/json; charset=UTF-8' },
-    }
-  );
+  const response = await fetch('/api/order/storefront/checkouts/' + id, {
+    method: 'GET',
+    headers: { 'Content-type': 'application/json; charset=UTF-8' },
+  });
   if (response.status >= 200 && response.status < 300) return response.json();
   return Promise.reject(response.status);
 }


### PR DESCRIPTION
When deploy to k8s environment the storefront application must change the NEXT_PUBLIC_API_BASE_PATH to another value, however the environment consist NEXT_PUBLIC  prefix that mean it is browser environment and cannot change when runtime,
and I saw only a function use this variable to fetch data on server side
https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables