### PR TITLE
Add username and password for elasticsearch client configuration

### DIFF
--- a/search/src/main/java/com/yas/search/config/ElasticsearchDataConfig.java
+++ b/search/src/main/java/com/yas/search/config/ElasticsearchDataConfig.java
@@ -1,0 +1,14 @@
+package com.yas.search.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties(prefix = "elasticsearch")
+@Configuration
+@Data
+public class ElasticsearchDataConfig {
+    private String url;
+    private String username;
+    private String password;
+}

--- a/search/src/main/java/com/yas/search/config/ImperativeClientConfig.java
+++ b/search/src/main/java/com/yas/search/config/ImperativeClientConfig.java
@@ -1,6 +1,6 @@
 package com.yas.search.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -10,14 +10,16 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "com.yas.search.repository")
 @ComponentScan(basePackages = "com.yas.search.service")
+@RequiredArgsConstructor
 public class ImperativeClientConfig extends ElasticsearchConfiguration {
-    @Value("${elasticsearch.url}")
-    private String elasticSearchUrl;
+
+    private final ElasticsearchDataConfig elasticsearchConfig;
 
     @Override
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
-                .connectedTo(elasticSearchUrl)
+                .connectedTo(elasticsearchConfig.getUrl())
+                .withBasicAuth(elasticsearchConfig.getUsername(), elasticsearchConfig.getPassword())
                 .build();
     }
 }

--- a/search/src/main/resources/application.properties
+++ b/search/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 elasticsearch.url=elasticsearch
+elasticsearch.username=
+elasticsearch.password=
 
 server.port=8092
 server.servlet.context-path=/search


### PR DESCRIPTION
On the elasticsearch server installing k8s require username and password when establish connection, however the search application lack of config for username and password