### PR TITLE
YAS-0002 fix docker build with versioning

### DIFF
--- a/backoffice-bff/Dockerfile
+++ b/backoffice-bff/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:21-jre-alpine
 RUN apk add --no-cache bash
-COPY target/backoffice-bff-0.0.1-SNAPSHOT.jar backoffice-bff-0.0.1-SNAPSHOT.jar
+COPY target/backoffice*.jar app.jar
 COPY wait-for-it.sh wait-for-it.sh
 RUN chmod +x wait-for-it.sh
-ENTRYPOINT ["java","-jar","/backoffice-bff-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/cart/Dockerfile
+++ b/cart/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/cart-0.0.1-SNAPSHOT.jar cart-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/cart-0.0.1-SNAPSHOT.jar"]
+ADD target/cart*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/customer/Dockerfile
+++ b/customer/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/customer-0.0.1-SNAPSHOT.jar customer-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/customer-0.0.1-SNAPSHOT.jar"]
+ADD target/customer*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/inventory/Dockerfile
+++ b/inventory/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/inventory-0.0.1-SNAPSHOT.jar inventory-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/inventory-0.0.1-SNAPSHOT.jar"]
+ADD target/inventory*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]
 

--- a/location/Dockerfile
+++ b/location/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/location-0.0.1-SNAPSHOT.jar location-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/location-0.0.1-SNAPSHOT.jar"]
+ADD target/location*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]
 

--- a/media/Dockerfile
+++ b/media/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-COPY target/media-0.0.1-SNAPSHOT.jar media-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java","-jar","/media-0.0.1-SNAPSHOT.jar"]
+COPY target/media*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/order/Dockerfile
+++ b/order/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre-alpine
 
-ADD target/order-0.0.1-SNAPSHOT.jar order.jar
-ENTRYPOINT ["java", "-jar", "/order.jar"]
+ADD target/order*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/payment/Dockerfile
+++ b/payment/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/payment-0.0.1-SNAPSHOT.jar payment-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/payment-0.0.1-SNAPSHOT.jar"]
+ADD target/payment*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/product/Dockerfile
+++ b/product/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/product-0.0.1-SNAPSHOT.jar product-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/product-0.0.1-SNAPSHOT.jar"]
+ADD target/product*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/promotion/Dockerfile
+++ b/promotion/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/promotion-0.0.1-SNAPSHOT.jar promotion-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/promotion-0.0.1-SNAPSHOT.jar"]
+ADD target/promotion*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/rating/Dockerfile
+++ b/rating/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/rating-0.0.1-SNAPSHOT.jar rating-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/rating-0.0.1-SNAPSHOT.jar"]
+ADD target/rating*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:21-jre-alpine
 RUN apk add --no-cache bash
-ADD target/search-0.0.1-SNAPSHOT.jar search-0.0.1-SNAPSHOT.jar
+ADD target/search*.jar app.jar
 COPY wait-for-it.sh wait-for-it.sh
 RUN chmod +x wait-for-it.sh
-ENTRYPOINT ["java", "-jar", "/search-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/storefront-bff/Dockerfile
+++ b/storefront-bff/Dockerfile
@@ -2,5 +2,5 @@ FROM eclipse-temurin:21-jre-alpine
 RUN apk add --no-cache bash
 COPY wait-for-it.sh wait-for-it.sh
 RUN chmod +x wait-for-it.sh
-COPY target/storefront-bff-0.0.1-SNAPSHOT.jar storefront-bff-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java","-jar","/storefront-bff-0.0.1-SNAPSHOT.jar"]
+COPY target/storefront*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/tax/Dockerfile
+++ b/tax/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre-alpine
-ADD target/tax-0.0.1-SNAPSHOT.jar tax-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/tax-0.0.1-SNAPSHOT.jar"]
+ADD target/tax*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]
 


### PR DESCRIPTION
From the last changing, the output jar version was updated by parent version, and these version can be changed any time. But the dockerfile is using the fixing version, that is the cause of deploy fail. To fix that, all the dockerfile using jar will the command copy with `*` to the target jar to app.jar and run with that name.