### PR TITLE
Turn of "Client authentication" for swagger ui client registration in keycloak

### DIFF
--- a/identity/realm-export.json
+++ b/identity/realm-export.json
@@ -1124,8 +1124,6 @@
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
       "redirectUris": [
         "http://localhost:8081/*",
         "http://localhost:8092/*",
@@ -1163,7 +1161,7 @@
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": false,
-      "publicClient": false,
+      "publicClient": true,
       "frontchannelLogout": false,
       "protocol": "openid-connect",
       "attributes": {


### PR DESCRIPTION
Turn of "Client authentication" for swagger ui client registration in keycloak