### PR TITLE
#940 #941 #942 Config ci flows, integration test, and jacoco

### DIFF
--- a/.github/workflows/backoffice-bff-ci.yaml
+++ b/.github/workflows/backoffice-bff-ci.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f backoffice-bff
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f backoffice-bff
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
+      - name: Run Maven Build Command
+        run: mvn clean install -f backoffice-bff
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:

--- a/.github/workflows/cart-ci.yaml
+++ b/.github/workflows/cart-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -pl cart -am
       - name: Run Maven Checkstyle
-        run: mvn checkstyle:checkstyle -pl cart -am
+        run: mvn checkstyle:checkstyle -f cart
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -pl cart -am
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f cart
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Cart-Service-Unit-Test-Results
-          path: "cart/**/surefire-reports/*.xml"
+          path: "cart/**/*-reports/*.xml"
           reporter: java-junit
       - name: OWASP Dependency Check
         uses: dependency-check/Dependency-Check_Action@main

--- a/.github/workflows/customer-ci.yaml
+++ b/.github/workflows/customer-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f customer
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f customer
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f customer
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f customer
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Customer-Service-Unit-Test-Results
-          path: "customer/**/surefire-reports/*.xml"
+          path: "customer/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/inventory-ci.yaml
+++ b/.github/workflows/inventory-ci.yaml
@@ -27,14 +27,14 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Verify
-        run: mvn verify -f inventory
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f inventory
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Unit Test Results
+      - name: Run Maven Verify
+        run: mvn install -f inventory
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:

--- a/.github/workflows/location-ci.yaml
+++ b/.github/workflows/location-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f location
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f location
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f location
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f location
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Location-Service-Unit-Test-Results
-          path: "location/**/surefire-reports/*.xml"
+          path: "location/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/media-ci.yaml
+++ b/.github/workflows/media-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f media
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f media
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f media
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f media
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Media-Service-Unit-Test-Results
-          path: "media/**/surefire-reports/*.xml"
+          path: "media/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/order-ci.yaml
+++ b/.github/workflows/order-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -pl order -am
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -pl order -am
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -pl order -am
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f order
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Order-Service-Unit-Test-Results
-          path: "order/**/surefire-reports/*.xml"
+          path: "order/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/payment-ci.yaml
+++ b/.github/workflows/payment-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -pl payment -am
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -pl payment -am
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -pl payment -am
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f payment
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Payment-Service-Unit-Test-Results
-          path: "payment/**/surefire-reports/*.xml"
+          path: "payment/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/payment-paypal-ci.yaml
+++ b/.github/workflows/payment-paypal-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f payment-paypal
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f payment-paypal
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f payment-paypal
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f payment-paypal
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Payment-Paypal-Unit-Test-Results
-          path: "payment-paypal/**/surefire-reports/*.xml"
+          path: "payment-paypal/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/product-ci.yaml
+++ b/.github/workflows/product-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -pl product -am
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -pl product -am
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -pl product -am
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f product
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Product-Service-Unit-Test-Results
-          path: "product/**/surefire-reports/*.xml"
+          path: "product/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/promotion-ci.yaml
+++ b/.github/workflows/promotion-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f promotion
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f promotion
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f promotion
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f promotion
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Promotion-Service-Unit-Test-Results
-          path: "promotion/**/surefire-reports/*.xml"
+          path: "promotion/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/rating-ci.yaml
+++ b/.github/workflows/rating-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f rating
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f rating
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f rating
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f rating
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Rating-Service-Unit-Test-Results
-          path: "rating/**/surefire-reports/*.xml"
+          path: "rating/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/sampledata-ci.yaml
+++ b/.github/workflows/sampledata-ci.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f sampledata
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f sampledata
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
+      - name: Run Maven Build Command
+        run: mvn clean install -f sampledata
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:

--- a/.github/workflows/search-ci.yaml
+++ b/.github/workflows/search-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f search
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f search
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f search
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f search
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Search-Service-Unit-Test-Results
-          path: "search/**/surefire-reports/*.xml"
+          path: "search/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/storefront-bff-ci.yaml
+++ b/.github/workflows/storefront-bff-ci.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f storefront-bff
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f storefront-bff
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
+      - name: Run Maven Build Command
+        run: mvn clean install -f storefront-bff
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:

--- a/.github/workflows/tax-ci.yaml
+++ b/.github/workflows/tax-ci.yaml
@@ -27,21 +27,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
-      - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f tax
       - name: Run Maven Checkstyle
         run: mvn checkstyle:checkstyle -f tax
       - uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/checkstyle-result.xml'
-      - name: Run Maven Test
-        run: mvn test -f tax
-      - name: Unit Test Results
+      - name: Run Maven Build Command
+        run: mvn clean install -f tax
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Tax-Service-Unit-Test-Results
-          path: "tax/**/surefire-reports/*.xml"
+          path: "tax/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/.github/workflows/webhook-ci.yaml
+++ b/.github/workflows/webhook-ci.yaml
@@ -28,15 +28,13 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
-        run: mvn clean install -DskipTests -f webhook
-      - name: Run Maven Test
-        run: mvn test -f webhook
+        run: mvn clean install -f webhook
       - name: Unit Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Webhook-Service-Unit-Test-Results
-          path: "webhook/**/surefire-reports/*.xml"
+          path: "webhook/**/*-reports/*.xml"
           reporter: java-junit
       - name: Analyze with sonar cloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
                         <!-- attached to Maven test phase -->
                         <execution>
                             <id>report</id>
-                            <phase>test</phase>
+                            <phase>verify</phase>
                             <goals>
                                 <goal>report</goal>
                             </goals>
@@ -353,7 +353,6 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>test</phase>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -368,23 +367,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>integration-test</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>

--- a/tax/src/it/resources/application.properties
+++ b/tax/src/it/resources/application.properties
@@ -11,3 +11,4 @@ spring.liquibase.enabled=false
 spring.security.oauth2.resourceserver.jwt.issuer-uri=test
 springdoc.oauthflow.authorization-url=test
 springdoc.oauthflow.token-url=test
+spring.jpa.open-in-view=false


### PR DESCRIPTION
- Remove the unnecessary integration test profile (We will be using the same profile as the unit test)
- Run integration tests during the integration test phase of the maven build cycle (`failsafe` plugin default behavior)
- Run `jacoco` `report` in verify phase (after integration test) so that it can also collect the integration test results for the coverage report
- Config ci for all service to:
  - Run `mvn install`, which includes `test` and `verify` phase (which contains the tests), as well as 'install' (which create the jar file on the local machine for `docker` image building process down the line
  - Run the `install` step, which is more costly, after the `checkstyle` step in order to reduce the pipelines run time in case `checkstyle` fail
  - Reconfigurate the test reports collectors to includes `failsafe` reports