### PR TITLE
[Location] Refactor create and update state-or-province:

### DIFF
--- a/backoffice/pages/location/state-or-provinces/index.tsx
+++ b/backoffice/pages/location/state-or-provinces/index.tsx
@@ -119,7 +119,6 @@ const StateOrProvinceList: NextPage = () => {
       <Table striped bordered hover>
         <thead>
           <tr>
-            <th>ID</th>
             <th>Name</th>
             <th>Code</th>
             <th>Type</th>
@@ -129,7 +128,6 @@ const StateOrProvinceList: NextPage = () => {
         <tbody>
           {stateOrProvinces.map((stateOrProvince) => (
             <tr key={stateOrProvince.id}>
-              <td>{stateOrProvince.id}</td>
               <td>{stateOrProvince.name}</td>
               <td>{stateOrProvince.code}</td>
               <td>{stateOrProvince.type}</td>

--- a/location/src/main/java/com/yas/location/repository/StateOrProvinceRepository.java
+++ b/location/src/main/java/com/yas/location/repository/StateOrProvinceRepository.java
@@ -42,4 +42,8 @@ public interface StateOrProvinceRepository extends JpaRepository<StateOrProvince
                                                       final Pageable pageable);
 
     List<StateOrProvince> findAllByCountryIdOrderByNameAsc(Long countryId);
+
+    boolean existsByNameIgnoreCaseAndCountryId(final String name, final Long countryId);
+
+    boolean existsByNameIgnoreCaseAndCountryIdAndIdNot(final String name, final Long countryId, final Long excludedId);
 }


### PR DESCRIPTION
- The create or update function will now verify the name ignore case of the state or province within that specific country, rather than across all countries.
- In the backoffice, the stateOrProvince ID display has been removed from the StateOrProvince section as it was deemed unnecessary.
- Refactor to sort by the name of the StateOrProvince by default, previously sorted by ID.