### PR TITLE
Fix model mismatch in backoffice and product service

### DIFF
--- a/backoffice/modules/catalog/components/ProductVariation.tsx
+++ b/backoffice/modules/catalog/components/ProductVariation.tsx
@@ -95,12 +95,23 @@ const ProductVariations = ({ getValue, setValue }: Props) => {
 
   const onGenerate = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
-    let formProductVariations = getValue('productVariations') || [];
+    const formProductVariations = getValue('productVariations') || [];
     const optionValuesByOptionId = generateProductOptionCombinations();
+    
+    if (optionValuesByOptionId.size === 0) {
+      return toast.warn("Please Input Values Option")
+    }
+    
     const productName = getValue('name');
     const variationName = [productName, ...Array.from(optionValuesByOptionId.values())]
       .join(' ')
       .trim();
+    
+      const checkVariationName = formProductVariations.some(variation => variation.optionName == variationName)
+
+    if (checkVariationName) {
+      return toast.warning("Combined Option Values are Duplicated")
+    }
 
     const newVariation: ProductVariation = {
       optionName: variationName,
@@ -115,19 +126,16 @@ const ProductVariations = ({ getValue, setValue }: Props) => {
 
   const generateProductOptionCombinations = (): Map<number, string> => {
     const optionValuesByOptionId = new Map<number, string>();
-    const formProductOptions = getValue('productOptions') || [];
-
+    let isEmptyOptions = false
     selectedOptions.forEach((option) => {
+      if (isEmptyOptions) return;
       const optionValue = (document.getElementById(option) as HTMLInputElement).value;
-
+      if (optionValue === "") { return isEmptyOptions = true }
       const productOption = productOptions.find((productOption) => productOption.name === option);
       const productOptionId = productOption?.id ?? -1;
-      formProductOptions.push({ productOptionId: productOptionId, value: [optionValue] });
-      setValue('productOptions', formProductOptions);
       optionValuesByOptionId.set(productOptionId, optionValue);
     });
-
-    return optionValuesByOptionId;
+    return isEmptyOptions ? new Map<number, string>() : optionValuesByOptionId;
   };
 
   const onDeleteVariation = (variant: ProductVariation) => {

--- a/backoffice/modules/catalog/components/ProductVariation.tsx
+++ b/backoffice/modules/catalog/components/ProductVariation.tsx
@@ -97,20 +97,22 @@ const ProductVariations = ({ getValue, setValue }: Props) => {
     event.preventDefault();
     const formProductVariations = getValue('productVariations') || [];
     const optionValuesByOptionId = generateProductOptionCombinations();
-    
+
     if (optionValuesByOptionId.size === 0) {
-      return toast.warn("Please Input Values Option")
+      return toast.warn('Please Input Values Option');
     }
-    
+
     const productName = getValue('name');
     const variationName = [productName, ...Array.from(optionValuesByOptionId.values())]
       .join(' ')
       .trim();
-    
-      const checkVariationName = formProductVariations.some(variation => variation.optionName == variationName)
+
+    const checkVariationName = formProductVariations.some(
+      (variation) => variation.optionName == variationName
+    );
 
     if (checkVariationName) {
-      return toast.warning("Combined Option Values are Duplicated")
+      return toast.warning('Combined Option Values are Duplicated');
     }
 
     const newVariation: ProductVariation = {
@@ -126,11 +128,13 @@ const ProductVariations = ({ getValue, setValue }: Props) => {
 
   const generateProductOptionCombinations = (): Map<number, string> => {
     const optionValuesByOptionId = new Map<number, string>();
-    let isEmptyOptions = false
+    let isEmptyOptions = false;
     selectedOptions.forEach((option) => {
       if (isEmptyOptions) return;
       const optionValue = (document.getElementById(option) as HTMLInputElement).value;
-      if (optionValue === "") { return isEmptyOptions = true }
+      if (optionValue === '') {
+        return (isEmptyOptions = true);
+      }
       const productOption = productOptions.find((productOption) => productOption.name === option);
       const productOptionId = productOption?.id ?? -1;
       optionValuesByOptionId.set(productOptionId, optionValue);

--- a/backoffice/modules/catalog/components/ProductVariation.tsx
+++ b/backoffice/modules/catalog/components/ProductVariation.tsx
@@ -133,7 +133,8 @@ const ProductVariations = ({ getValue, setValue }: Props) => {
       if (isEmptyOptions) return;
       const optionValue = (document.getElementById(option) as HTMLInputElement).value;
       if (optionValue === '') {
-        return (isEmptyOptions = true);
+        isEmptyOptions = true;
+        return;
       }
       const productOption = productOptions.find((productOption) => productOption.name === option);
       const productOptionId = productOption?.id ?? -1;

--- a/backoffice/modules/catalog/models/FormProduct.ts
+++ b/backoffice/modules/catalog/models/FormProduct.ts
@@ -29,6 +29,5 @@ export type FormProduct = {
   crossSell?: number[]; // product id
   productAttributes?: ProductAttributeValue[];
   productVariations?: ProductVariation[];
-  productOptions?: ProductOptionValuePost[];
   taxClassId?: number;
 };

--- a/backoffice/modules/catalog/models/FormProduct.ts
+++ b/backoffice/modules/catalog/models/FormProduct.ts
@@ -1,6 +1,5 @@
 import { Media } from './Media';
 import { ProductAttributeValue } from './ProductAttributeValue';
-import { ProductOptionValuePost } from './ProductOptionValuePost';
 import { ProductVariation } from './ProductVariation';
 
 export type FormProduct = {

--- a/backoffice/modules/catalog/models/ProductPayload.ts
+++ b/backoffice/modules/catalog/models/ProductPayload.ts
@@ -59,18 +59,18 @@ export function mapFormProductToProductPayload(data: FormProduct): ProductPayloa
     productImageIds: data.productImageMedias?.map((image) => image.id),
     variations: data.productVariations
       ? data.productVariations.map((variant) => {
-        return {
-          id: variant.id,
-          name: variant.optionName,
-          slug: slugify(variant.optionName, { lower: true, strict: true }),
-          sku: variant.optionSku,
-          gtin: variant.optionGTin,
-          price: variant.optionPrice,
-          thumbnailMediaId: variant.optionThumbnail?.id,
-          productImageIds: variant.optionImages?.map((image) => image.id),
-          optionValuesByOptionId: variant.optionValuesByOptionId,
-        };
-      })
+          return {
+            id: variant.id,
+            name: variant.optionName,
+            slug: slugify(variant.optionName, { lower: true, strict: true }),
+            sku: variant.optionSku,
+            gtin: variant.optionGTin,
+            price: variant.optionPrice,
+            thumbnailMediaId: variant.optionThumbnail?.id,
+            productImageIds: variant.optionImages?.map((image) => image.id),
+            optionValuesByOptionId: variant.optionValuesByOptionId,
+          };
+        })
       : [],
     productOptionValues: createProductOptionValues(data.productVariations || []),
     relatedProductIds: data.relateProduct,
@@ -81,24 +81,25 @@ export function mapFormProductToProductPayload(data: FormProduct): ProductPayloa
 const createProductOptionValues = (productVariations: ProductVariation[]) => {
   let productOptionValues: ProductOptionValuePost[] = [];
   productVariations.map((variation) => {
-    const option = variation.optionValuesByOptionId
+    const option = variation.optionValuesByOptionId;
     Object.entries(option).map((entry) => {
       const id = +entry[0];
       const value = entry[1];
-      let optionValue = productOptionValues.find((option) => { return option.productOptionId === id })
+      let optionValue = productOptionValues.find((option) => {
+        return option.productOptionId === id;
+      });
       if (optionValue) {
         if (!optionValue.value.includes(value)) {
-          optionValue.value.push(value)
+          optionValue.value.push(value);
         }
-      }
-      else {
+      } else {
         productOptionValues.push({
           productOptionId: id,
           displayOrder: 1,
-          value: [value]
-        })
+          value: [value],
+        });
       }
-    })
-  })
-  return productOptionValues
-}
+    });
+  });
+  return productOptionValues;
+};

--- a/backoffice/modules/catalog/models/ProductPayload.ts
+++ b/backoffice/modules/catalog/models/ProductPayload.ts
@@ -80,9 +80,9 @@ export function mapFormProductToProductPayload(data: FormProduct): ProductPayloa
 
 const createProductOptionValues = (productVariations: ProductVariation[]) => {
   let productOptionValues: ProductOptionValuePost[] = [];
-  productVariations.map((variation) => {
+  productVariations.forEach((variation) => {
     const option = variation.optionValuesByOptionId;
-    Object.entries(option).map((entry) => {
+    Object.entries(option).forEach((entry) => {
       const id = +entry[0];
       const value = entry[1];
       let optionValue = productOptionValues.find((option) => {

--- a/backoffice/modules/catalog/models/ProductPayload.ts
+++ b/backoffice/modules/catalog/models/ProductPayload.ts
@@ -4,6 +4,7 @@ import { FormProduct } from './FormProduct';
 import { ProductOptionValuePost } from './ProductOptionValuePost';
 import { ProductVariationPost } from './ProductVariationPost';
 import { ProductVariationPut } from './ProductVariationPut';
+import { ProductVariation } from './ProductVariation';
 
 export type ProductPayload = {
   name?: string;
@@ -58,21 +59,46 @@ export function mapFormProductToProductPayload(data: FormProduct): ProductPayloa
     productImageIds: data.productImageMedias?.map((image) => image.id),
     variations: data.productVariations
       ? data.productVariations.map((variant) => {
-          return {
-            id: variant.id,
-            name: variant.optionName,
-            slug: slugify(variant.optionName, { lower: true, strict: true }),
-            sku: variant.optionSku,
-            gtin: variant.optionGTin,
-            price: variant.optionPrice,
-            thumbnailMediaId: variant.optionThumbnail?.id,
-            productImageIds: variant.optionImages?.map((image) => image.id),
-            optionValuesByOptionId: variant.optionValuesByOptionId,
-          };
-        })
+        return {
+          id: variant.id,
+          name: variant.optionName,
+          slug: slugify(variant.optionName, { lower: true, strict: true }),
+          sku: variant.optionSku,
+          gtin: variant.optionGTin,
+          price: variant.optionPrice,
+          thumbnailMediaId: variant.optionThumbnail?.id,
+          productImageIds: variant.optionImages?.map((image) => image.id),
+          optionValuesByOptionId: variant.optionValuesByOptionId,
+        };
+      })
       : [],
-    productOptionValues: data.productOptions?.map((option) => ({ ...option, displayOrder: 1 })),
+    productOptionValues: createProductOptionValues(data.productVariations || []),
     relatedProductIds: data.relateProduct,
     taxClassId: data.taxClassId,
   };
+}
+
+const createProductOptionValues = (productVariations: ProductVariation[]) => {
+  let productOptionValues: ProductOptionValuePost[] = [];
+  productVariations.map((variation) => {
+    const option = variation.optionValuesByOptionId
+    Object.entries(option).map((entry) => {
+      const id = +entry[0];
+      const value = entry[1];
+      let optionValue = productOptionValues.find((option) => { return option.productOptionId === id })
+      if (optionValue) {
+        if (!optionValue.value.includes(value)) {
+          optionValue.value.push(value)
+        }
+      }
+      else {
+        productOptionValues.push({
+          productOptionId: id,
+          displayOrder: 1,
+          value: [value]
+        })
+      }
+    })
+  })
+  return productOptionValues
 }


### PR DESCRIPTION
- Create function to build correct productOptionValues object before request.
- Remove productOptions from FormProduct, this variable could cause problem when delete variations, both in FE and BE, as it is a standalone variable from productVariations, which will make options persisted even though product variations have been deleted.
- Check empty option value(s), any option should not have empty value like this:
![image](https://github.com/user-attachments/assets/ad5d04b8-30bb-46cc-8c2c-70c8a3782629)
