### PR TITLE
Add validate vs dirty check to price field

### DIFF
--- a/backoffice/modules/catalog/components/ProductGeneralInformation.tsx
+++ b/backoffice/modules/catalog/components/ProductGeneralInformation.tsx
@@ -52,7 +52,7 @@ const ProductGeneralInformation = ({ register, errors, setValue }: Props) => {
           setValue('taxClassId', data.taxClassId ?? '');
           setValue('description', data.description ?? '');
           setValue('specification', data.specification ?? '');
-          setValue('price', data.price ?? 0);
+          setValue('price', data.price ?? 0, { shouldValidate: true, shouldDirty: true });
           setLoading(false);
         })
         .catch((error) => {


### PR DESCRIPTION
### Product can now be updated without generating errors on price field, even if users do not modify anything after accessing ProductInformation page.
<img width="940" alt="ppr3" src="https://github.com/user-attachments/assets/4821c9af-6299-4d6b-a69e-cd852cabd2dd">
