### PR TITLE
Handle error when fetching the get-average-star API on Product Detail page

### DIFF
--- a/storefront/pages/products/[slug].tsx
+++ b/storefront/pages/products/[slug].tsx
@@ -115,10 +115,13 @@ const ProductDetailsPage = ({ product, productOptions, productVariations, pvid }
   const [averageStar, setAverageStar] = useState<number>(0);
 
   useEffect(() => {
-    getAverageStarByProductId(product.id).then((res) => {
-      setAverageStar(res);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    getAverageStarByProductId(product.id)
+      .then((res) => {
+        setAverageStar(res);
+      })
+      .catch((error) => {
+        console.error('Error fetching average star:', error);
+      });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### Error accessing the 'Product Detail' page locally when rating module is not running. This error occurs because the exception is not yet being caught when fetching the API.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/6eca6eb9-58eb-4027-bbb6-7ed20dcab239">


