### PR TITLE
ci: fix workflow permissions, coverage threshold 70%, docker registry, gitleaks

### DIFF
--- a/.github/workflows/backoffice-bff-ci.yaml
+++ b/.github/workflows/backoffice-bff-ci.yaml
@@ -1,4 +1,4 @@
-name: backoffice-bff service ci
+﻿name: backoffice-bff service ci
 
 on:
   push:
@@ -20,28 +20,40 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
+      - name: Run Maven Build Command
+        run: mvn clean install -pl backoffice-bff -am
       - name: Run Maven Checkstyle
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        run: mvn checkstyle:checkstyle -f backoffice-bff -Dcheckstyle.output.file=backoffice-bff-checkstyle-result.xml
+        run: mvn checkstyle:checkstyle -pl backoffice-bff -am -Dcheckstyle.output.file=backoffice-bff-checkstyle-result.xml
       - name: Upload Checkstyle Result
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/backoffice-bff-checkstyle-result.xml'
-      - name: Run Maven Verify
-        run: mvn clean verify -f backoffice-bff
-      - name: Analyze with sonar cloud
+      - name: Test Results
+        uses: dorny/test-reporter@v1
+        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
+        with:
+          name: Backoffice-Bff-Service-Unit-Test-Results
+          path: "backoffice-bff/**/*-reports/TEST*.xml"
+          reporter: java-junit
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f backoffice-bff
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl backoffice-bff -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -53,21 +65,31 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-backoffice-bff-Report
           path: ${{github.workspace}}/reports
-      - name: Log in to the Container registry
+      - name: Add coverage report to PR
+        uses: madrapps/jacoco-report@v1.6.1
+        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
+        with:
+          paths: ${{github.workspace}}/backoffice-bff/target/site/jacoco/jacoco.xml
+          token: ${{secrets.GITHUB_TOKEN}}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          title: 'Backoffice-Bff Coverage Report'
+          update-comment: true
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./backoffice-bff
           push: true
-          tags: ghcr.io/nashtech-garage/yas-backoffice-bff:latest
+          tags: ghcr.io/nat90711/yas-backoffice-bff:latest

--- a/.github/workflows/backoffice-ci.yaml
+++ b/.github/workflows/backoffice-ci.yaml
@@ -1,4 +1,4 @@
-name: backoffice service ci
+﻿name: backoffice service ci
 
 on:
   push:
@@ -18,6 +18,11 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
@@ -65,12 +70,12 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./backoffice
-          tags: ghcr.io/nashtech-garage/yas-backoffice:latest
+          tags: ghcr.io/nat90711/yas-backoffice:latest
       - name: Run Trivy vulnerability scanner
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: 'ghcr.io/nashtech-garage/yas-backoffice:latest'
+          image-ref: 'ghcr.io/nat90711/yas-backoffice:latest'
           format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Push Docker image
@@ -79,7 +84,7 @@ jobs:
         with:
           push: true
           context: ./backoffice
-          tags: ghcr.io/nashtech-garage/yas-backoffice:latest
+          tags: ghcr.io/nat90711/yas-backoffice:latest
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/cart-ci.yaml
+++ b/.github/workflows/cart-ci.yaml
@@ -1,4 +1,4 @@
-name: cart service ci
+﻿name: cart service ci
 
 on:
   push:
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl cart -am
@@ -44,6 +49,11 @@ jobs:
           name: Cart-Service-Unit-Test-Results
           path: "cart/**/*-reports/TEST*.xml"
           reporter: java-junit
+      - name: Analyze with SonarCloud
+        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl cart -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -55,36 +65,31 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-cart-Report
           path: ${{github.workspace}}/reports
-      - name: Analyze with sonar cloud
-        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl cart -am
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         with:
           paths: ${{github.workspace}}/cart/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Cart Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./cart
           push: true
-          tags: ghcr.io/nashtech-garage/yas-cart:latest
+          tags: ghcr.io/nat90711/yas-cart:latest

--- a/.github/workflows/customer-ci.yaml
+++ b/.github/workflows/customer-ci.yaml
@@ -1,4 +1,4 @@
-name: customer service ci
+﻿name: customer service ci
 
 on:
   push:
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl customer -am
@@ -44,11 +49,11 @@ jobs:
           name: Customer-Service-Unit-Test-Results
           path: "customer/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f customer
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl customer -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-customer-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/customer/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Customer Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./customer
           push: true
-          tags: ghcr.io/nashtech-garage/yas-customer:latest
+          tags: ghcr.io/nat90711/yas-customer:latest

--- a/.github/workflows/delivery-ci.yaml
+++ b/.github/workflows/delivery-ci.yaml
@@ -1,19 +1,19 @@
-﻿name: tax service ci
+﻿name: delivery service ci
 
 on:
   push:
     branches: [ "main" ]
     paths:
-      - "tax/**"
+      - "delivery/**"
       - ".github/workflows/actions/action.yaml"
-      - ".github/workflows/tax-ci.yaml"
+      - ".github/workflows/delivery-ci.yaml"
       - "pom.xml"
   pull_request:
     branches: [ "main" ]
     paths:
-      - "tax/**"
+      - "delivery/**"
       - ".github/workflows/actions/action.yaml"
-      - ".github/workflows/tax-ci.yaml"
+      - ".github/workflows/delivery-ci.yaml"
       - "pom.xml"
   workflow_dispatch:
 
@@ -33,27 +33,27 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
-        run: mvn clean install -pl tax -am
+        run: mvn clean install -pl delivery -am
       - name: Run Maven Checkstyle
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        run: mvn checkstyle:checkstyle -pl tax -am -Dcheckstyle.output.file=tax-checkstyle-result.xml
+        run: mvn checkstyle:checkstyle -pl delivery -am -Dcheckstyle.output.file=delivery-checkstyle-result.xml
       - name: Upload Checkstyle Result
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
-          path: '**/tax-checkstyle-result.xml'
+          path: '**/delivery-checkstyle-result.xml'
       - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
-          name: Tax-Service-Unit-Test-Results
-          path: "tax/**/*-reports/TEST*.xml"
+          name: Delivery-Service-Unit-Test-Results
+          path: "delivery/**/*-reports/TEST*.xml"
           reporter: java-junit
       - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl tax -am
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl delivery -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -67,17 +67,17 @@ jobs:
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: OWASP-tax-Report
+          name: OWASP-delivery-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         with:
-          paths: ${{github.workspace}}/tax/target/site/jacoco/jacoco.xml
+          paths: ${{github.workspace}}/delivery/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
           min-coverage-overall: 70
           min-coverage-changed-files: 70
-          title: 'Tax Coverage Report'
+          title: 'Delivery Coverage Report'
           update-comment: true
       - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -90,6 +90,6 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
-          context: ./tax
+          context: ./delivery
           push: true
-          tags: ghcr.io/nat90711/yas-tax:latest
+          tags: ghcr.io/nat90711/yas-delivery:latest

--- a/.github/workflows/gitleaks-check.yaml
+++ b/.github/workflows/gitleaks-check.yaml
@@ -1,17 +1,26 @@
-name: GitLeaks check nightly
+name: GitLeaks Secret Scan
+
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
   schedule:
     - cron: "0 0 * * *"
+
 jobs:
-  check:
+  gitleaks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-    - name: Checkout 
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-    - name: Gitleaks check
-      run: |
-        docker pull zricethezav/gitleaks:v8.18.4
-        docker run --rm -v ${{ github.workspace }}:/work -w /work zricethezav/gitleaks:v8.18.4 detect --source="." --config="/work/gitleaks.toml" --verbose --no-git
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gitleaks Check
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/inventory-ci.yaml
+++ b/.github/workflows/inventory-ci.yaml
@@ -1,15 +1,15 @@
-name: inventory service ci
+﻿name: inventory service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "inventory/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/inventory-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "inventory/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl inventory -am
@@ -41,9 +46,14 @@ jobs:
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
-          name: Inventory-Service-Test-Results
+          name: Inventory-Service-Unit-Test-Results
           path: "inventory/**/*-reports/TEST*.xml"
           reporter: java-junit
+      - name: Analyze with SonarCloud
+        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl inventory -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -55,36 +65,31 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-inventory-Report
           path: ${{github.workspace}}/reports
-      - name: Analyze with sonar cloud
-        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f inventory
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         with:
           paths: ${{github.workspace}}/inventory/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Inventory Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./inventory
           push: true
-          tags: ghcr.io/nashtech-garage/yas-inventory:latest
+          tags: ghcr.io/nat90711/yas-inventory:latest

--- a/.github/workflows/location-ci.yaml
+++ b/.github/workflows/location-ci.yaml
@@ -1,15 +1,15 @@
-name: location service ci
+﻿name: location service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "location/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/location-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "location/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl location -am
@@ -44,11 +49,11 @@ jobs:
           name: Location-Service-Unit-Test-Results
           path: "location/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f location
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl location -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-location-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/location/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Location Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./location
           push: true
-          tags: ghcr.io/nashtech-garage/yas-location:latest
+          tags: ghcr.io/nat90711/yas-location:latest

--- a/.github/workflows/media-ci.yaml
+++ b/.github/workflows/media-ci.yaml
@@ -1,4 +1,4 @@
-name: media service ci
+﻿name: media service ci
 
 on:
   push:
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl media -am
@@ -44,7 +49,7 @@ jobs:
           name: Media-Service-Unit-Test-Results
           path: "media/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-media-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/media/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Media Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./media
           push: true
-          tags: ghcr.io/nashtech-garage/yas-media:latest
+          tags: ghcr.io/nat90711/yas-media:latest

--- a/.github/workflows/order-ci.yaml
+++ b/.github/workflows/order-ci.yaml
@@ -1,15 +1,15 @@
-name: order service ci
+﻿name: order service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "order/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/order-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "order/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl order -am
@@ -44,11 +49,11 @@ jobs:
           name: Order-Service-Unit-Test-Results
           path: "order/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f order
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl order -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-order-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/order/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Order Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./order
           push: true
-          tags: ghcr.io/nashtech-garage/yas-order:latest
+          tags: ghcr.io/nat90711/yas-order:latest

--- a/.github/workflows/payment-ci.yaml
+++ b/.github/workflows/payment-ci.yaml
@@ -1,15 +1,15 @@
-name: payment service ci
+﻿name: payment service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "payment/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/payment-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "payment/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl payment -am
@@ -44,11 +49,11 @@ jobs:
           name: Payment-Service-Unit-Test-Results
           path: "payment/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f payment
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl payment -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-payment-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/payment/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Payment Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./payment
           push: true
-          tags: ghcr.io/nashtech-garage/yas-payment:latest
+          tags: ghcr.io/nat90711/yas-payment:latest

--- a/.github/workflows/payment-paypal-ci.yaml
+++ b/.github/workflows/payment-paypal-ci.yaml
@@ -1,15 +1,15 @@
-name: payment-paypal service ci
+﻿name: payment-paypal service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "payment-paypal/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/payment-paypal-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "payment-paypal/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl payment-paypal -am
@@ -41,14 +46,14 @@ jobs:
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
-          name: Payment-Paypal-Unit-Test-Results
+          name: Payment-Paypal-Service-Unit-Test-Results
           path: "payment-paypal/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f payment-paypal
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl payment-paypal -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-payment-paypal-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/payment-paypal/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
-          title: 'Payment Paypal Coverage Report'
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          title: 'Payment-Paypal Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./payment-paypal
           push: true
-          tags: ghcr.io/nashtech-garage/yas-payment-paypal:latest
+          tags: ghcr.io/nat90711/yas-payment-paypal:latest

--- a/.github/workflows/product-ci.yaml
+++ b/.github/workflows/product-ci.yaml
@@ -1,4 +1,4 @@
-name: product service ci
+﻿name: product service ci
 
 on:
   push:
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl product -am
@@ -44,11 +49,11 @@ jobs:
           name: Product-Service-Unit-Test-Results
           path: "product/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f product
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl product -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-product-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/product/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Product Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./product
           push: true
-          tags: ghcr.io/nashtech-garage/yas-product:latest
+          tags: ghcr.io/nat90711/yas-product:latest

--- a/.github/workflows/promotion-ci.yaml
+++ b/.github/workflows/promotion-ci.yaml
@@ -1,15 +1,15 @@
-name: promotion service ci
+﻿name: promotion service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "promotion/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/promotion-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "promotion/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl promotion -am
@@ -44,11 +49,11 @@ jobs:
           name: Promotion-Service-Unit-Test-Results
           path: "promotion/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f promotion
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl promotion -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-promotion-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/promotion/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Promotion Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./promotion
           push: true
-          tags: ghcr.io/nashtech-garage/yas-promotion:latest
+          tags: ghcr.io/nat90711/yas-promotion:latest

--- a/.github/workflows/rating-ci.yaml
+++ b/.github/workflows/rating-ci.yaml
@@ -1,15 +1,15 @@
-name: rating service ci
+﻿name: rating service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "rating/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/rating-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "rating/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl rating -am
@@ -44,11 +49,11 @@ jobs:
           name: Rating-Service-Unit-Test-Results
           path: "rating/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f rating
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl rating -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-rating-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/rating/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Rating Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./rating
           push: true
-          tags: ghcr.io/nashtech-garage/yas-rating:latest
+          tags: ghcr.io/nat90711/yas-rating:latest

--- a/.github/workflows/recommendation-ci.yaml
+++ b/.github/workflows/recommendation-ci.yaml
@@ -1,15 +1,15 @@
-name: recommendation service ci
+﻿name: recommendation service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "recommendation/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/recommendation-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "recommendation/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl recommendation -am
@@ -44,7 +49,7 @@ jobs:
           name: Recommendation-Service-Unit-Test-Results
           path: "recommendation/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-recommendation-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/recommendation/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Recommendation Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./recommendation
           push: true
-          tags: ghcr.io/nashtech-garage/yas-recommendation:latest
+          tags: ghcr.io/nat90711/yas-recommendation:latest

--- a/.github/workflows/sampledata-ci.yaml
+++ b/.github/workflows/sampledata-ci.yaml
@@ -1,4 +1,4 @@
-name: sampledata service ci
+﻿name: sampledata service ci
 
 on:
   push:
@@ -20,6 +20,11 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
@@ -70,4 +75,4 @@ jobs:
         with:
           context: ./sampledata
           push: true
-          tags: ghcr.io/nashtech-garage/yas-sampledata:latest
+          tags: ghcr.io/nat90711/yas-sampledata:latest

--- a/.github/workflows/search-ci.yaml
+++ b/.github/workflows/search-ci.yaml
@@ -1,15 +1,15 @@
-name: search service ci
+﻿name: search service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "search/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/search-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "search/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl search -am
@@ -44,11 +49,11 @@ jobs:
           name: Search-Service-Unit-Test-Results
           path: "search/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f search
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl search -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-search-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/search/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Search Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./search
           push: true
-          tags: ghcr.io/nashtech-garage/yas-search:latest
+          tags: ghcr.io/nat90711/yas-search:latest

--- a/.github/workflows/storefront-bff-ci.yaml
+++ b/.github/workflows/storefront-bff-ci.yaml
@@ -1,4 +1,4 @@
-name: storefront-bff service ci
+﻿name: storefront-bff service ci
 
 on:
   push:
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl storefront-bff -am
@@ -37,11 +42,18 @@ jobs:
         uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/storefront-bff-checkstyle-result.xml'
-      - name: Analyze with sonar cloud
+      - name: Test Results
+        uses: dorny/test-reporter@v1
+        if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
+        with:
+          name: Storefront-Bff-Service-Unit-Test-Results
+          path: "storefront-bff/**/*-reports/TEST*.xml"
+          reporter: java-junit
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f storefront-bff
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl storefront-bff -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -53,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-storefront-bff-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -63,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/storefront-bff/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
-          title: 'Storefront BFF Coverage Report'
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          title: 'Storefront-Bff Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./storefront-bff
           push: true
-          tags: ghcr.io/nashtech-garage/yas-storefront-bff:latest
+          tags: ghcr.io/nat90711/yas-storefront-bff:latest

--- a/.github/workflows/storefront-ci.yaml
+++ b/.github/workflows/storefront-ci.yaml
@@ -1,4 +1,4 @@
-name: storefront service ci
+﻿name: storefront service ci
 
 on:
   push:
@@ -18,6 +18,11 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
@@ -56,4 +61,4 @@ jobs:
         with:
           context: ./storefront
           push: true
-          tags: ghcr.io/nashtech-garage/yas-storefront:latest
+          tags: ghcr.io/nat90711/yas-storefront:latest

--- a/.github/workflows/webhook-ci.yaml
+++ b/.github/workflows/webhook-ci.yaml
@@ -1,15 +1,15 @@
-name: webhook service ci
+﻿name: webhook service ci
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "webhook/**"
       - ".github/workflows/actions/action.yaml"
       - ".github/workflows/webhook-ci.yaml"
       - "pom.xml"
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
     paths:
       - "webhook/**"
       - ".github/workflows/actions/action.yaml"
@@ -20,12 +20,17 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      packages: write
     env:
       FROM_ORIGINAL_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - uses: ./.github/workflows/actions
       - name: Run Maven Build Command
         run: mvn clean install -pl webhook -am
@@ -37,18 +42,18 @@ jobs:
         uses: jwgmeligmeyling/checkstyle-github-action@master
         with:
           path: '**/webhook-checkstyle-result.xml'
-      - name: Unit Test Results
+      - name: Test Results
         uses: dorny/test-reporter@v1
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' && (success() || failure()) }}
         with:
           name: Webhook-Service-Unit-Test-Results
           path: "webhook/**/*-reports/TEST*.xml"
           reporter: java-junit
-      - name: Analyze with sonar cloud
+      - name: Analyze with SonarCloud
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -f webhook
+        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl webhook -am
       - name: OWASP Dependency Check
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
         uses: dependency-check/Dependency-Check_Action@main
@@ -60,9 +65,9 @@ jobs:
           format: 'HTML'
       - name: Upload OWASP Dependency Check results
         if: ${{ env.FROM_ORIGINAL_REPOSITORY == 'true' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
-          name: OWASP Dependency Check Report
+          name: OWASP-webhook-Report
           path: ${{github.workspace}}/reports
       - name: Add coverage report to PR
         uses: madrapps/jacoco-report@v1.6.1
@@ -70,21 +75,21 @@ jobs:
         with:
           paths: ${{github.workspace}}/webhook/target/site/jacoco/jacoco.xml
           token: ${{secrets.GITHUB_TOKEN}}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 60
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
           title: 'Webhook Coverage Report'
           update-comment: true
-      - name: Log in to the Container registry
+      - name: Log in to Container registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
           context: ./webhook
           push: true
-          tags: ghcr.io/nashtech-garage/yas-webhook:latest
+          tags: ghcr.io/nat90711/yas-webhook:latest

--- a/backoffice-bff/pom.xml
+++ b/backoffice-bff/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
     <name>backoffice-bff</name>
     <description>Backend for backoffice</description>
     <properties>
-        <sonar.projectKey>nashtech-garage_yas-backoffice-bff</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-backoffice-bff</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/cart/pom.xml
+++ b/cart/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -14,9 +14,9 @@
     <description>YAS Cart service</description>
 
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-cart</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-cart</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/common-library/pom.xml
+++ b/common-library/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -16,9 +16,9 @@
     <description>YAS Common Library service</description>
 
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-common-library</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-common-library</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/customer/pom.xml
+++ b/customer/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -13,9 +13,9 @@
     <description>YAS Customer service</description>
 
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-customer</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-customer</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/delivery/pom.xml
+++ b/delivery/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -16,9 +16,9 @@
     <description>YAS Delivery service</description>
 
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-delivery</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-delivery</sonar.projectKey>
     </properties>
 
 </project>

--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>inventory</name>
     <description>YAS Inventory Service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-inventory</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-inventory</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/location/pom.xml
+++ b/location/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>location</name>
     <description>YAS Location Service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-location</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-location</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/media/pom.xml
+++ b/media/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>media</name>
     <description>Yas Media service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-media</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-media</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/order/pom.xml
+++ b/order/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -12,9 +12,9 @@
     <name>order</name>
     <description>Order Service for yas project</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-order</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-order</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/payment-paypal/pom.xml
+++ b/payment-paypal/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -14,9 +14,9 @@
     <name>payment-paypal</name>
     <description>Payment with paypal service for yas project</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-payment-paypal</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-payment-paypal</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -12,9 +12,9 @@
     <name>payment</name>
     <description>Payment Service for Yas Project</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-payment</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-payment</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -14,9 +14,9 @@
     <description>YAS Product service</description>
 
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-product</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-product</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/promotion/pom.xml
+++ b/promotion/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>promotion</name>
     <description>YAS Promotion Service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-promotion</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-promotion</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/rating/pom.xml
+++ b/rating/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -12,9 +12,9 @@
     <name>rating</name>
     <description>YAS Rating service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-rating</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-rating</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/sampledata/pom.xml
+++ b/sampledata/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -14,9 +14,9 @@
     <description>YAS sampledata service</description>
 
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-sampledata</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-sampledata</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>search</name>
     <description>Demo project for Spring Boot</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-search</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-search</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/storefront-bff/pom.xml
+++ b/storefront-bff/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>storefront-bff</name>
     <description>Back end for Storefront</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-storefront-bff</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-storefront-bff</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/tax/pom.xml
+++ b/tax/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
     <name>tax</name>
     <description>YAS Tax Service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-tax</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-tax</sonar.projectKey>
     </properties>
     <dependencies>
         <dependency>

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -13,9 +13,9 @@
 	<name>webhook</name>
 	<description>YAS Webhook service</description>
     <properties>
-        <sonar.organization>nashtech-garage</sonar.organization>
+        <sonar.organization>Nat90711</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>nashtech-garage_yas-webhook</sonar.projectKey>
+        <sonar.projectKey>Nat90711_yas-webhook</sonar.projectKey>
     </properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Changes in this PR

### CI Workflow Fixes (all 18+ service workflows)
- Added permissions block (contents, checks, pull-requests, packages) to fix CI check upload issues
- - Updated Docker image registry from nashtech-garage to Nat90711
- - Set coverage threshold to 70% (both overall and changed files) per project requirement #792 - Upgraded upload-artifact from @master to @v4
- - Fixed unique artifact names per service (OWASP reports)
### Gitleaks Update
- Switched from Docker-based gitleaks to official gitleaks/gitleaks-action@v2
- - Now runs on pull_request events (not just nightly schedule)
### New: delivery-ci.yaml
- Added missing CI workflow for the delivery service
### Coverage
- min-coverage-overall: 70 
- - min-coverage-changed-files: 70