### PR TITLE
ci: add advisory Arcade architecture analysis

### DIFF
--- a/.github/workflows/arcade-architecture-analysis.yml
+++ b/.github/workflows/arcade-architecture-analysis.yml
@@ -1,0 +1,28 @@
+name: Arcade Architecture Analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  analyze:
+    name: Architecture advisory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lemduc/arcade-agent/actions/analyze@v0.1.1
+        with:
+          arcade-agent-version: "0.1.1"
+          language: java
+          primary-algorithm: pkg
+          run-secondary-analyses: "false"
+          upload-artifacts: "true"
+          post-pr-comment: "true"


### PR DESCRIPTION
## What changed

- add an advisory Arcade architecture analysis workflow for pull requests, `main` pushes, and manual runs
- pin both the composite action and installed package to released version `v0.1.1`
- analyze Java with the package-based recovery algorithm, upload the report, and store a default-branch baseline
- keep secondary analyses disabled to reduce CI time and update one idempotent PR summary when write access is available

## Why

YAS has many independently built services. This workflow adds a repository-level dependency view that complements the existing per-service CI without changing any service build or setting a merge threshold.

The `issues: write` and `pull-requests: write` permissions are used only for the idempotent analysis comment. The action skips comments for forked pull requests, where GitHub does not grant a write token.

## Impact

This is CI-only and advisory. It does not modify Java, Maven, deployment, or runtime behavior.

## Validation

- `actionlint` passed for the workflow
- released `arcade-agent[languages]==0.1.1` completed a local Java/package baseline against `179e813568c3`
- baseline recovered 1,985 entities, 8,671 dependency edges, and 21 components

The detailed baseline interpretation is included in a separate PR comment.
